### PR TITLE
[ update ] to match the new version of the test lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,12 @@ testbin:
 test-only:
 	${MAKE} -C tests only=$(only)
 
+# only run the tests that fail during the last run
+retest-only:
+	${MAKE} -C tests retest
+
 test: build install testbin test-only
+retest: build install testbin retest-only
 
 time-time:
 	time ${MAKE} test INTERACTIVE=''

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -5,7 +5,7 @@ import Test.Golden
 %default covering
 
 allTests : TestPool
-allTests = MkTestPool []
+allTests = MkTestPool "Name of the pool" []
   [ "test001"
   , "test002" -- To add more tests, copy one of the test directories, then update this list
   ]

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,7 +3,11 @@ INTERACTIVE ?= --interactive
 .PHONY: testbin test
 
 test:
-	./build/exec/runtests idrall $(INTERACTIVE) --only $(only)
+	./build/exec/runtests idris2 $(INTERACTIVE) --failure-file failures --only $(only)
+
+retest:
+	@touch failures
+	./build/exec/runtests idris2 $(INTERACTIVE) --failure-file failures --only-file failures --only $(only)
 
 testbin:
 	idris2 --build tests.ipkg

--- a/tests/helloidris2/test001/run
+++ b/tests/helloidris2/test001/run
@@ -1,3 +1,3 @@
-idris2 --no-banner --no-color --console-width 0 -p helloidris2 Main.idr < input
+$1 --no-banner --no-color --console-width 0 -p helloidris2 Main.idr < input
 
 rm -rf build

--- a/tests/helloidris2/test002/run
+++ b/tests/helloidris2/test002/run
@@ -1,3 +1,3 @@
-idris2 --no-banner --no-color --console-width 0 -p helloidris2 Greet.idr --client ":exec main"
+$1 --no-banner --no-color --console-width 0 -p helloidris2 Greet.idr --client ":exec main"
 
 rm -rf build


### PR DESCRIPTION
* Test pools now take a name
* We have a convenient way to rerun the tests that failed at the
  previous iteration